### PR TITLE
Use Nix to provision a now complete Docker container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
 # Build environment for sparkle
-FROM ubuntu:xenial
-MAINTAINER Arnaud Bailly <arnaud@igitur.io>
+FROM nixos/nix
+MAINTAINER Mathieu Boespflug <m@tweag.io>
 
-# install GHC
-# from https://github.com/freebroccolo/docker-haskell/blob/master/7.10/Dockerfile
-ENV LANG            C.UTF-8
+# stack --docker needs groupadd, which is found in the shadow package (only in edge).
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories
+RUN apk --update add ca-certificates python shadow
 
-RUN echo 'deb http://download.fpcomplete.com/ubuntu xenial main' > /etc/apt/sources.list.d/fpco.list && \
-    echo 'deb http://ppa.launchpad.net/cwchien/gradle/ubuntu xenial main' > /etc/apt/sources.list.d/gradle.list && \
-    # fpco key
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5705533DA4F78D8664B5DC0575159689BEFB442 && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3D16156328D0E3056D885D0BD7CC6F019D06AF36 && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-      ca-certificates \
-      gradle \
-      netbase \
-      # we need JDK because jre does not ship with libjvm.so...
-      openjdk-8-jdk \
-      stack
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable && nix-channel --update
+ADD shell.nix /
+RUN nix-shell /shell.nix
+RUN nix-env -i stack
+# This is necessary because Stack overrides the initial PATH to some hardcoded value.
+RUN mkdir -p /usr/bin \
+    && ln -s $(readlink -f $(which nix-shell)) /usr/bin/nix-shell
+
+ADD entrypoint.py /
+ENTRYPOINT ["/entrypoint.py"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,13 @@ RUN mkdir -p /usr/bin \
 # https://github.com/1science/docker-elasticsearch/issues/1#issuecomment-106307522
 RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
 
+# A very long line in /etc/group is not necessary and prevents newer groups to
+# be found. Fixes the error:
+#   $ stack --docker --docker-image sparkle build
+#   Running /usr/sbin/useradd -oN --uid 1000 --gid 1000 --home .../_home stack exited with ExitFailure 6
+#   useradd: group '1000' does not exist
+RUN sed -i 's/nixbld:x:30000:.*/nixbld:x:30000:/g' /etc/group
+
 ADD entrypoint.py /
 ENTRYPOINT ["/entrypoint.py"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ RUN nix-env -i stack
 RUN mkdir -p /usr/bin \
     && ln -s $(readlink -f $(which nix-shell)) /usr/bin/nix-shell
 
+# Workaround for Java getLocalHost() failure.
+# https://github.com/1science/docker-elasticsearch/issues/1#issuecomment-106307522
+RUN echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+
 ADD entrypoint.py /
 ENTRYPOINT ["/entrypoint.py"]
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -111,23 +111,8 @@ This image can be used to build sparkle then package and run applications:
 ...
 ```
 
-Note that you will need to edit the `stack.yaml` file to point to
-include directories and libraries for building the C bits that
-interact with the JVM:
-
-```
-extra-include-dirs:
-  - '/usr/lib/jvm/java-1.8.0-openjdk-amd64/include'
-  - '/usr/lib/jvm/java-1.8.0-openjdk-amd64/include/linux'
-extra-lib-dirs:
-  - '/usr/lib/jvm/java-1.8.0-openjdk-amd64/jre/lib/amd64/server/'
-```
-
-Once everything is built you can generate a spark package and run it using `sparkle`'s command-line:
-
-```
-# stack --docker --docker-image sparkle exec sparkle package sparkle-example-hello
-```
+Package Spark apps and execute them as in the Linux-native case,
+making sure to pass `--docker` as a parameter as above.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Sparkle: Apache Spark applications in Haskell
+# `sparkle`: Apache Spark applications in Haskell
 
 [![Circle CI](https://circleci.com/gh/tweag/sparkle.svg?style=svg)](https://circleci.com/gh/tweag/sparkle)
 
-*Sparkle [spär′kəl]:* a library for writing resilient analytics
+*sparkle [spär′kəl]:* a library for writing resilient analytics
 applications in Haskell that scale to thousands of nodes, using
 [Spark][spark] and the rest of the Apache ecosystem under the hood.
 See [this blog post][hello-sparkle] for the details.
@@ -22,10 +22,7 @@ $ stack exec -- sparkle package sparkle-example-hello
 $ stack exec -- spark-submit --master 'local[1]' sparkle-example-hello.jar
 ```
 
-**Requirements:**
-* the [Stack][stack] build tool (version 1.2 or above);
-* either, the [Nix][nix] package manager,
-* or, OpenJDK, Gradle and Spark (version 1.6) installed from your distro.
+## How to use
 
 To run a Spark application the process is as follows:
 
@@ -38,6 +35,16 @@ To run a Spark application the process is as follows:
 
 **If you run into issues, read the Troubleshooting section below
   first.**
+
+### Build
+
+#### Linux
+
+**Requirements**
+
+* the [Stack][stack] build tool (version 1.2 or above);
+* either, the [Nix][nix] package manager,
+* or, OpenJDK, Gradle and Spark (version 1.6) installed from your distro.
 
 To build:
 
@@ -61,11 +68,38 @@ nix:
   enable: true
 ```
 
+#### Non-Linux OSes
+
+`sparkle` is not supported on non-Linux operating systems (e.g. Mac OS X or
+Windows). To build and use sparkle from such an OS, use the provided
+`Dockerfile` and build everything in [Docker](http://docker.io):
+
+```
+$ docker build -t sparkle .
+```
+
+This will create a Docker image named `sparkle` that contains everything
+needed to build sparkle and Spark applications, including Stack, Java 8, and
+Gradle.
+
+The image can be used to build sparkle then package and run applications:
+
+```
+$ docker run -it -v $(pwd):/src sparkle
+# cd /src
+# stack --nix --allow-different-user build
+...
+```
+
+### Package
+
 To package your app as a JAR directly consumable by Spark:
 
 ```
 $ stack exec -- sparkle package <app-executable-name>
 ```
+
+### Submit
 
 Finally, to run your application, for example locally:
 
@@ -92,31 +126,9 @@ the [Databricks hosted platform][databricks] and on
 [databricks]: https://databricks.com/
 [aws-emr]: https://aws.amazon.com/emr/
 
-### Non-Linux OSes
-
-Sparkle is not currently supported on non-linux OSes, e.g. Mac OS X or Windows. If you want to build and use it from a machine using
-such an OS, you can use the provided `Dockerfile` and build everything in [docker](http://docker.io):
-
-```
-$ docker build -t sparkle .
-```
-
-will create an image named `sparkle` containing everything that's
-needed to build sparkle and Spark applications: Stack, Java 8, Gradle.
-
-This image can be used to build sparkle then package and run applications:
-
-```
-# stack --docker --docker-image sparkle build
-...
-```
-
-Package Spark apps and execute them as in the Linux-native case,
-making sure to pass `--docker` as a parameter as above.
-
 ## How it works
 
-sparkle is a tool for creating self-contained Spark applications in
+`sparkle` is a tool for creating self-contained Spark applications in
 Haskell. Spark applications are typically distributed as JAR files, so
 that's what sparkle creates. We embed Haskell native object code as
 compiled by GHC in these JAR files, along with any shared library
@@ -158,14 +170,14 @@ Copyright (c) 2015-2016 EURL Tweag.
 
 All rights reserved.
 
-Sparkle is free software, and may be redistributed under the terms
+`sparkle` is free software, and may be redistributed under the terms
 specified in the [LICENSE](LICENSE) file.
 
 ## About
 
 ![Tweag I/O](http://i.imgur.com/0HK8X4y.png)
 
-Sparkle is maintained by [Tweag I/O](http://tweag.io/).
+`sparkle` is maintained by [Tweag I/O](http://tweag.io/).
 
 Have questions? Need help? Tweet at
 [@tweagio](http://twitter.com/tweagio).

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from subprocess import call
+
+args = []
+for i in range(1, len(sys.argv)):
+    # Quote all arguments, just in case they were so originally.
+    args.append("\"%s\"" % sys.argv[i])
+    # XXX hack: If calling Stack have to pass env var as arguments.
+    if sys.argv[i] == 'stack':
+        args.append('$STACK_IN_NIX_EXTRA_ARGS')
+
+command = ["nix-shell", "/shell.nix", "--run"] + [' '.join(args)]
+
+call(command)

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,6 @@
-{ nixpkgs ? import <nixpkgs> {}, ghc }:
+{ nixpkgs ? import <nixpkgs> {}
+, ghc ? nixpkgs.haskell.compiler.ghc7103   # Default needed for Docker build.
+}:
 
 with nixpkgs;
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,6 @@ extra-deps:
 nix:
   # Requires Stack >= 1.2.
   shell-file: shell.nix
+docker:
+  enable: false
+  stack-exe: image

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,4 +13,5 @@ nix:
   shell-file: shell.nix
 docker:
   enable: false
+  run-args: ["--net=bridge"]
   stack-exe: image


### PR DESCRIPTION
The previous Docker container for the project included Java, but not
Spark. So while it was enough to *build* sparkle, it wasn't enough to
run Spark applications built using sparkle. This new Docker image
contains everything that is needed to both build and run apps.

In order to avoid the Nix shell.nix and the Docker Dockerfile from
drifting away from each other over time, we actually provision nearly
all system dependencies in the image using Nix. However, we *don't*
use Stack's --nix support nested inside Stack's --docker support.
Instead, we crafted a special entrypoint for the container that makes
Stack oblivious to the very existence of Nix. Stack just blithely
grabs stuff from the current PATH, however it was provided to it by
Nix.